### PR TITLE
Add explicit OpenVINO version on pipeline build

### DIFF
--- a/HandTracker.py
+++ b/HandTracker.py
@@ -82,6 +82,7 @@ class HandTracker:
         print("Creating pipeline...")
         # Start defining a pipeline
         pipeline = dai.Pipeline()
+        pipeline.setOpenVINOVersion(version = dai.OpenVINO.Version.VERSION_2021_2)
         self.pd_input_length = 128
 
         if self.camera:


### PR DESCRIPTION
To avoid issues when depthai library is updated to the latest OpenVINO version, which is not backward compatible with the compiled models.

